### PR TITLE
Hide progress bar during intro questions

### DIFF
--- a/workspace/src/components/ProgressBar.tsx
+++ b/workspace/src/components/ProgressBar.tsx
@@ -5,7 +5,7 @@ export default function ProgressBar() {
   const { getProgress, state } = useSurvey();
   const progress = getProgress();
 
-  if (!state.user) return null;
+  if (!state.user || state.memberType === 'intro') return null;
 
   return (
     <div className="mt-4">


### PR DESCRIPTION
## Summary
- prevent ProgressBar from rendering for intro member type

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*