### PR TITLE
Update question count when member type chosen

### DIFF
--- a/workspace/src/contexts/SurveyContext.tsx
+++ b/workspace/src/contexts/SurveyContext.tsx
@@ -16,6 +16,7 @@ type SurveyAction =
   | { type: 'START_SURVEY'; payload: { user: User; totalQuestions: number } }
   | { type: 'ANSWER_QUESTION'; payload: SurveyResponse }
   | { type: 'SET_MEMBER_TYPE'; payload: 'intro' | 'current' | 'new' | 'previous' }
+  | { type: 'SET_TOTAL_QUESTIONS'; payload: number }
   | { type: 'NEXT_QUESTION' }
   | { type: 'PREVIOUS_QUESTION' }
   | { type: 'SET_LOADING'; payload: boolean }
@@ -58,6 +59,11 @@ function surveyReducer(state: SurveyState, action: SurveyAction): SurveyState {
         ...state,
         memberType: action.payload,
       };
+    case 'SET_TOTAL_QUESTIONS':
+      return {
+        ...state,
+        totalQuestions: action.payload,
+      };
     case 'NEXT_QUESTION':
       return {
         ...state,
@@ -96,6 +102,7 @@ interface SurveyContextType {
   state: SurveyState;
   startSurvey: (totalQuestions: number) => void;
   answerQuestion: (questionId: string, answer: string | string[] | number | Record<string, string>) => void;
+  setTotalQuestions: (total: number) => void;
   nextQuestion: () => void;
   previousQuestion: () => void;
   completeSurvey: () => void;
@@ -120,6 +127,10 @@ export function SurveyProvider({ children }: { children: ReactNode }) {
     // Start with 'intro' type to show intro questions first
     dispatch({ type: 'SET_MEMBER_TYPE', payload: 'intro' });
     dispatch({ type: 'START_SURVEY', payload: { user, totalQuestions } });
+  };
+
+  const setTotalQuestions = (total: number) => {
+    dispatch({ type: 'SET_TOTAL_QUESTIONS', payload: total });
   };
 
   const answerQuestion = (questionId: string, answer: string | string[] | number | Record<string, string>) => {
@@ -231,6 +242,7 @@ export function SurveyProvider({ children }: { children: ReactNode }) {
         state,
         startSurvey,
         answerQuestion,
+        setTotalQuestions,
         nextQuestion,
         previousQuestion,
         completeSurvey,

--- a/workspace/src/pages/Survey.tsx
+++ b/workspace/src/pages/Survey.tsx
@@ -8,8 +8,9 @@ import NavigationButtons from '../components/NavigationButtons';
 export default function Survey() {
   const { 
     state, 
-    startSurvey, 
-    getResponse, 
+    startSurvey,
+    getResponse,
+    setTotalQuestions,
     nextQuestion: contextNextQuestion,
     previousQuestion: contextPreviousQuestion,
     shouldShowQuestion
@@ -57,8 +58,10 @@ export default function Survey() {
 
     if (!state.user) {
       startSurvey(nonIntroQuestions.length);
+    } else if (state.memberType && state.memberType !== 'intro') {
+      setTotalQuestions(nonIntroQuestions.length);
     }
-  }, [questionSection, state.memberType, startSurvey]);
+  }, [questionSection, state.memberType, startSurvey, setTotalQuestions]);
 
   // Custom function to find the next valid question to show
   const findNextValidQuestion = (startIndex: number) => {


### PR DESCRIPTION
## Summary
- add `SET_TOTAL_QUESTIONS` reducer action and handler
- expose `setTotalQuestions` through `SurveyContext`
- update `Survey` page to recompute total question count after screener

## Testing
- `npm run build` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*